### PR TITLE
julia_setup() fails to correctly load libjulia.dll if the JULIA_HOME ist not in path

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -52,7 +52,12 @@ julia_setup <- function(JULIA_HOME = NULL, verbose = TRUE, force = FALSE, useRCa
 
     if (.Platform$OS.type == "windows") {
         libm <- julia_line(c("-e", "print(Libdl.dlpath(Base.libm_name))"), stdout = TRUE)
-        dyn.load(libm)
+        dyn.load(libm, DLLpath= .julia$bin_dir)
+
+        # following is required to load dll dependencies from JULIA_HOME
+        cur_dir <- getwd()
+        setwd(.julia$bin_dir)
+        on.exit(setwd(cur_dir))
     }
 
     juliacall_initialize(.julia$dll_file)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -52,7 +52,12 @@ julia_setup <- function(JULIA_HOME = NULL, verbose = TRUE, force = FALSE, useRCa
 
     if (.Platform$OS.type == "windows") {
         libm <- julia_line(c("-e", "print(Libdl.dlpath(Base.libm_name))"), stdout = TRUE)
-        dyn.load(libm)
+        dyn.load(libm, DLLpath= .julia$bin_dir)
+
+        # following is required to load dll dependencies from JULIA_HOME
+        cur_dir <- getwd()
+        setwd(.julia$bin_dir)
+        on.exit(setwd(cur_dir))
     }
 
     juliacall_initialize(.julia$dll_file)
@@ -117,7 +122,7 @@ julia_setup <- function(JULIA_HOME = NULL, verbose = TRUE, force = FALSE, useRCa
     if (interactive()) {
         julia_command("eval(Base, :(is_interactive = true));")
     }
-    
+
     julia_call("Base.load_juliarc")
 
     if (isTRUE(getOption("jupyter.in_kernel"))) {


### PR DESCRIPTION
calling `julia_setup(path) `results in error like this:
```
Julia version 0.6.1 at location c:\programs\julia-0.6.1\bin will be used.
Julia initiation...
Error in inDL(x, as.logical(local), as.logical(now), ...) : 
  unable to load shared object 'c:/programs/julia-0.6.1/bin/libopenlibm.DLL':
  LoadLibrary failure:  The specified module could not be found.
```
aparnetly it is a windows problem with resolving the loacation of the DLLs required by  libopenlibm.DLL and libjulia.dll, though they are all in the JULIA_HOME folder.

This PR fixes the issue on my machine. 