### PR TITLE
Get JULIA_HOME from environment variable

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -20,7 +20,11 @@ julia_locate <- function(JULIA_HOME = NULL){
         JULIA_HOME <- getOption("JULIA_HOME")
     }
     if (is.null(JULIA_HOME)) {
-        JULIA_HOME <- Sys.getenv("JULIA_HOME")
+        JULIA_HOME <- if(Sys.getenv("JULIA_HOME") == ""){
+            NULL
+        } else{
+            Sys.getenv("JULIA_HOME")
+        }
     }
 
     if (is.null(JULIA_HOME)) {

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -19,6 +19,9 @@ julia_locate <- function(JULIA_HOME = NULL){
     if (is.null(JULIA_HOME)) {
         JULIA_HOME <- getOption("JULIA_HOME")
     }
+    if (is.null(JULIA_HOME)) {
+        JULIA_HOME <- Sys.getenv("JULIA_HOME")
+    }
 
     if (is.null(JULIA_HOME)) {
         ## In macOS, the environment variables, e.g., PATH of a GUI is set by launchctl not the SHELL.


### PR DESCRIPTION
`JULIA_HOME` is the major environment variable in Julia language.
That's why I add the statement to get this value from environment variable .
- https://docs.julialang.org/en/stable/manual/environment-variables/#JULIA_HOME-1