### PR TITLE
added a way to find Julia.exe on Windows when JULIA_HOME is not set 

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -25,13 +25,19 @@ julia_locate <- function(JULIA_HOME = NULL){
             if (.Platform$OS.type == "unix") {
                 julia_bin <- system2("bash", "-l -c 'which julia'", stdout = TRUE)[1]
             } else if (.Platform$OS.type == "windows" ) {
-                windows_login_id <- Sys.info()[["login"]]
-                if(windows_login_id == "unknown") {
-                    stop("The Windows login is 'unknown'. Can not find julia executable")
+                # look for julia in the most common installation path
+                appdata_local_path <- Sys.getenv("LOCALAPPDATA")
+
+
+                # if the path is not defined, then try to construct it manually
+                if(appdata_local_path == "") {
+                    windows_login_id <- Sys.info()[["login"]]
+                    if(windows_login_id == "unknown") {
+                        stop("The Windows login is 'unknown'. Can not find julia executable")
+                    }
+                    appdata_local_path <- file.path("C:/Users/", windows_login_id, "AppData/Local")
                 }
 
-                # look for julia in the most common installation path
-                appdata_local_path <- file.path("C:/Users/", windows_login_id, "AppData/Local")
 
                 # get a list of folder names
                 ld <- list.dirs(appdata_local_path, recursive = FALSE, full.names = FALSE)

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -25,14 +25,23 @@ julia_locate <- function(JULIA_HOME = NULL){
             if (.Platform$OS.type == "unix") {
                 julia_bin <- system2("bash", "-l -c 'which julia'", stdout = TRUE)[1]
             } else if (.Platform$OS.type == "windows" ) {
+                windows_login_id <- Sys.info()[["login"]]
+                if(windows_login_id == "unknown") {
+                    stop("The Windows login is 'unknown'. Can not find julia executable")
+                }
+
                 # look for julia in the most common installation path
-                appdata_local_path <- file.path(sprintf("C:/Users/%s", Sys.info()[["login"]]), "AppData/Local")
+                appdata_local_path <- file.path("C:/Users/", windows_login_id, "AppData/Local")
 
                 # get a list of folder names
                 ld <- list.dirs(appdata_local_path, recursive = FALSE, full.names = FALSE)
 
                 # which of these folers start with "Julia"
                 x = ld[sort(which(substr(ld,1,5) == "Julia"))]
+
+                if(length(x) == 0) {
+                    stop(sprintf("Can not find the Julia installation in the default installation path '%s'", appdata_local_path))
+                }
                 # TODO if interactive() let the user choose a version of Julia
                 # keep the lastest version of Julia as that is likeley to be the default
                 x = x[length(x)]

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -24,6 +24,21 @@ julia_locate <- function(JULIA_HOME = NULL){
         if (julia_bin == "") {
             if (.Platform$OS.type == "unix") {
                 julia_bin <- system2("bash", "-l -c 'which julia'", stdout = TRUE)[1]
+            } else if (.Platform$OS.type == "windows" ) {
+                # look for julia in the most common installation path
+                appdata_local_path <- file.path(sprintf("C:/Users/%s", Sys.info()[["login"]]), "AppData/Local")
+
+                # get a list of folder names
+                ld <- list.dirs(appdata_local_path, recursive = FALSE, full.names = FALSE)
+
+                # which of these folers start with "Julia"
+                x = ld[sort(which(substr(ld,1,5) == "Julia"))]
+                # TODO if interactive() let the user choose a version of Julia
+                # keep the lastest version of Julia as that is likeley to be the default
+                x = x[length(x)]
+
+                # filter the ld for folders that starts with Julia
+                julia_bin <- file.path(appdata_local_path, x, "bin/julia.exe")
             } else {
                 julia_bin <- "julia"
             }
@@ -54,4 +69,4 @@ newer <- function(x, y){
     x <- substring(x, 1, 5)
     y <- substring(y, 1, 5)
     utils::compareVersion(x, y) >= 0
-    }
+}


### PR DESCRIPTION
added a way to find Julia.exe on Windows when JULIA_HOME is not set and `Sys.which("julia")` fails to find Julia

## Description
I couldn't find my julia.exe using `setup_julia()` so I've provided a way to find the `julia.exe` in the most common install path which is `c:/Users/Login/AppData/Local`. Sure enough I found the one I am looking

## Related Issue
None

## Example
This is not really testable.