### PR TITLE
Workaround for #99 (could not load library on multiarch installs)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # 0.17.1.9000
 
 * Fix bug for Julia plot in RMarkdown document caused by change of knitr #1717.
+* Workaround for #99: `ERROR: could not load library` on Debian/Ubuntu and
+  other systems which build Julia with `MULTIARCH_INSTALL=1` (#143 by @liskin).
 
 # JuliaCall 0.17.1
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -122,6 +122,13 @@ The issue is usually caused by updates in R, and it can be typically solved by s
 JuliaCall::julia_setup(rebuild = TRUE)
 ```
 
+### `ERROR: could not load library "/usr/lib/x86_64-linux-gnu/../bin/../lib/x86_64-linux-gnu/julia/sys.so"`
+
+This error happens when Julia is built/installed with `MULTIARCH_INSTALL=1`, as
+it is on e.g. Debian. It is caused by [the bindir-locating code in jl\_init not
+being multiarch-aware](https://github.com/JuliaLang/julia/issues/32614#issuecomment-656787386).
+To work around it, try setting `JULIA_BINDIR=/usr/bin` in [`.Renviron`](https://rstats.wtf/r-startup.html#renviron).
+
 ### How to Get Help
 
 - One way to get help for Julia functions is just using `julia$help` as the following example:

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ see <https://julialang.org/> for more information. Below is an image for
 JuliaCall brings **more than 100 times speedup** of the calculation\!
 See
 <https://github.com/Non-Contradiction/JuliaCall/tree/master/example/mandelbrot>
-for more
-information.
+for more information.
 
 ![](https://non-contradiction.github.io/JuliaCall/articles/mandelbrot.png)
 
@@ -74,7 +73,7 @@ section](#troubleshooting-and-way-to-get-help).
 ``` r
 library(JuliaCall)
 julia <- julia_setup()
-#> Julia version 1.0.3 at location /Applications/Julia-1.0.app/Contents/Resources/julia/bin will be used.
+#> Julia version 1.5.2 at location /usr/bin will be used.
 #> Loading setup script for JuliaCall...
 #> Finish loading setup script for JuliaCall.
 
@@ -112,7 +111,7 @@ julia_exists("c")
 
 julia_install_package_if_needed("Optim")
 julia_installed_package("Optim")
-#> [1] "0.18.1"
+#> [1] "1.2.0"
 julia_library("Optim")
 ```
 
@@ -168,7 +167,7 @@ julia_help("sqrt")
 #> 9.0
 #> 
 #> julia> sqrt(big(-81))
-#> ERROR: DomainError with -8.1e+01:
+#> ERROR: DomainError with -81.0:
 #> NaN result for non-NaN input.
 #> Stacktrace:
 #>  [1] sqrt(::BigFloat) at ./mpfr.jl:501
@@ -184,7 +183,9 @@ julia_help("sqrt")
 #> 
 #> If `A` has no negative real eigenvalues, compute the principal matrix square root of `A`, that is the unique matrix $X$ with eigenvalues having positive real part such that $X^2 = A$. Otherwise, a nonprincipal square root is returned.
 #> 
-#> If `A` is symmetric or Hermitian, its eigendecomposition ([`eigen`](@ref)) is used to compute the square root. Otherwise, the square root is determined by means of the Björck-Hammarling method [^BH83], which computes the complex Schur form ([`schur`](@ref)) and then the complex square root of the triangular factor.
+#> If `A` is real-symmetric or Hermitian, its eigendecomposition ([`eigen`](@ref)) is used to compute the square root.   For such matrices, eigenvalues λ that appear to be slightly negative due to roundoff errors are treated as if they were zero More precisely, matrices with all eigenvalues `≥ -rtol*(max |λ|)` are treated as semidefinite (yielding a Hermitian square root), with negative eigenvalues taken to be zero. `rtol` is a keyword argument to `sqrt` (in the Hermitian/real-symmetric case only) that defaults to machine precision scaled by `size(A,1)`.
+#> 
+#> Otherwise, the square root is determined by means of the Björck-Hammarling method [^BH83], which computes the complex Schur form ([`schur`](@ref)) and then the complex square root of the triangular factor.
 #> 
 #> [^BH83]: Åke Björck and Sven Hammarling, "A Schur method for the square root of a matrix", Linear Algebra and its Applications, 52-53, 1983, 127-140. [doi:10.1016/0024-3795(83)80010-X](https://doi.org/10.1016/0024-3795(83)80010-X)
 #> 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ follows.
 JuliaCall::julia_setup(rebuild = TRUE)
 ```
 
+### `ERROR: could not load library "/usr/lib/x86_64-linux-gnu/../bin/../lib/x86_64-linux-gnu/julia/sys.so"`
+
+This error happens when Julia is built/installed with
+`MULTIARCH_INSTALL=1`, as it is on e.g. Debian. It is caused by [the
+bindir-locating code in jl\_init not being
+multiarch-aware](https://github.com/JuliaLang/julia/issues/32614#issuecomment-656787386).
+To work around it, try setting `JULIA_BINDIR=/usr/bin` in
+[`.Renviron`](https://rstats.wtf/r-startup.html#renviron).
+
 ### How to Get Help
 
   - One way to get help for Julia functions is just using `julia$help`

--- a/src/JuliaCall.cpp
+++ b/src/JuliaCall.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <Rcpp.h>
 #include "libjulia.h"
 
@@ -17,7 +18,11 @@ bool juliacall_initialize(const std::string& libpath) {
         stop(get_last_loaded_symbol() + " - " + get_last_dl_error_message());
     }
 
-    jl_init();
+    const char *julia_bindir = getenv("JULIA_BINDIR");
+    if (julia_bindir)
+        jl_init_with_image(julia_bindir, NULL);
+    else
+        jl_init();
 
     if (!load_libjulia_modules()) {
         stop(get_last_dl_error_message());

--- a/src/libjulia.cpp
+++ b/src/libjulia.cpp
@@ -119,6 +119,8 @@ bool load_libjulia_symbols() {
     // load jl_init
     if (!(load_symbol(libjulia_t, "jl_init", (void**) &jl_init) || load_symbol(libjulia_t, "jl_init__threading", (void**) &jl_init)))
         return false;
+    if (!(load_symbol(libjulia_t, "jl_init_with_image", (void**) &jl_init_with_image) || load_symbol(libjulia_t, "jl_init_with_image__threading", (void**) &jl_init_with_image)))
+        return false;
     LOAD_JULIA_SYMBOL(jl_atexit_hook);
     LOAD_JULIA_SYMBOL(jl_eval_string);
 

--- a/src/libjulia.h
+++ b/src/libjulia.h
@@ -87,6 +87,8 @@ STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
 // initialization functions
 JL_EXTERN int (*jl_is_initialized)(void);
 JL_EXTERN void (*jl_init)(void);
+JL_EXTERN void (*jl_init_with_image)(const char *julia_bindir,
+                                     const char *image_relative_path);
 JL_EXTERN void (*jl_atexit_hook)(int status);
 
 // front end interface


### PR DESCRIPTION
## Description

Julia's embedding fails in jl_init if Julia is built and installed with
MULTIARCH_INSTALL=1, which it is in Debian and Ubuntu. It fails with:

    > julia_setup()
    Julia version 1.5.2 at location /usr/bin will be used.
    ERROR: could not load library "/usr/lib/x86_64-linux-gnu/../bin/../lib/x86_64-linux-gnu/julia/sys.so"
    /usr/lib/x86_64-linux-gnu/../bin/../lib/x86_64-linux-gnu/julia/sys.so: cannot open shared object file: No such file or directory

The problem is described at https://github.com/JuliaLang/julia/issues/32614#issuecomment-656787386.

As a workaround, let's allow overriding the bindir by setting
JULIA_BINDIR environment variable (`/usr/bin` to fix this on Debian).

## Related Issue

Fixes: https://github.com/Non-Contradiction/JuliaCall/issues/99