### PR TITLE
Fix Pkg.installed deprecation

### DIFF
--- a/inst/julia/install_dependency.jl
+++ b/inst/julia/install_dependency.jl
@@ -10,13 +10,21 @@ CurrentRhome = normpath(ARGS[1])
 ENV["R_HOME"] = CurrentRhome
 
 const julia07 = VERSION > v"0.6.5"
+const julia14 = VERSION > v"1.3.2"
 
 if julia07
     using Pkg
 end
 
 function installed(name)
-    @static if julia07
+    @static if julia14
+        for p in values(Pkg.dependencies())
+            if p.name == name && p.is_direct_dep
+                return p.version
+            end
+        end
+        nothing
+    elseif julia07
         get(Pkg.installed(), name, nothing)
     else
         Pkg.installed(name)

--- a/inst/julia/rebuildRCall.jl
+++ b/inst/julia/rebuildRCall.jl
@@ -10,6 +10,7 @@ CurrentRhome = normpath(ARGS[1])
 ENV["R_HOME"] = CurrentRhome
 
 const julia07 = VERSION > v"0.6.5"
+const julia14 = VERSION > v"1.3.2"
 
 if julia07
     using Pkg
@@ -18,7 +19,14 @@ else
 end
 
 function installed(name)
-    @static if julia07
+    @static if julia14
+        for p in values(Pkg.dependencies())
+            if p.name == name && p.is_direct_dep
+                return p.version
+            end
+        end
+        nothing
+    elseif julia07
         get(Pkg.installed(), name, nothing)
     else
         Pkg.installed(name)

--- a/inst/julia/setup.jl
+++ b/inst/julia/setup.jl
@@ -16,6 +16,7 @@ end
 module JuliaCall
 
 const julia07 = VERSION > v"0.6.5"
+const julia14 = VERSION > v"1.3.2"
 
 if julia07
     using Pkg
@@ -47,7 +48,14 @@ else
 end
 
 function installed(name)
-    @static if julia07
+    @static if julia14
+        for p in values(Pkg.dependencies())
+            if p.name == name && p.is_direct_dep
+                return p.version
+            end
+        end
+        nothing
+    elseif julia07
         get(Pkg.installed(), name, nothing)
     else
         Pkg.installed(name)


### PR DESCRIPTION
`Pkg.installed` is deprecated on Julia 1.4+, this changes to use the new `Pkg.dependencies` instead to avoid the dep warning