### PR TITLE
Workaround for macOS on Julia 1.6+

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release'}
-          ## - {os: macOS-latest, r: 'release'}
+          - {os: macOS-latest, r: 'release'}
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -119,6 +119,13 @@ julia_setup <- function(JULIA_HOME = NULL, verbose = TRUE,
         on.exit(setwd(cur_dir))
     }
 
+    # workaround for Julia 1.6+ (see https://github.com/JuliaPy/pyjulia/issues/437#issuecomment-912223632)
+    if (identical(get_os(), "osx")) {
+        cur_dir <- getwd()
+        setwd(dirname(.julia$dll_file))
+        on.exit(setwd(cur_dir))
+    }
+
     ## seems okay to try to load libjulia earlier, except on osx
     if (!identical(get_os(), "osx")) {
         try(dyn.load(.julia$dll_file))


### PR DESCRIPTION
## Description
This implements the workaround described [here](https://github.com/Non-Contradiction/JuliaCall/issues/164#issuecomment-912542332) to avoid problems loading libjulia. FWIW this workaround was also included in the latest version of pyjulia, so it seems like a consistent way to get around the issue

## Related Issue
Fixes #164
