### PR TITLE
knitr::wrap() depracted use knitr::sew()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Encoding: UTF-8
 Imports: utils,
     Rcpp (>= 0.12.7),
     knitr (>= 1.28)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 LinkingTo: Rcpp
 NeedsCompilation: yes
 ByteCompile: yes

--- a/R/RMarkdown.R
+++ b/R/RMarkdown.R
@@ -28,13 +28,9 @@ output_return <- function(){
 #' @importFrom knitr knit_print
 #' @export
 knit_print.JuliaOutput = function(x, ...) {
-    options = knitr::opts_current$get()
-    wrap_ <- do.call(":::", list("knitr", quote(wrap)))
-    wrap <- function(x) wrap_(x, options = options)
-
+    wrap <- function(x) knitr::sew(x, options = knitr::opts_current$get())
     knitr::asis_output(paste(c(wrap(x$stdout), wrap(x$out)),
                              collapse = "\n"))
-
 }
 
 ## This function is used at the beginning of Julia plot_display function

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // juliacall_initialize
 bool juliacall_initialize(const std::string& libpath, const std::string& julia_bindir, const std::string& image_path);
 RcppExport SEXP _JuliaCall_juliacall_initialize(SEXP libpathSEXP, SEXP julia_bindirSEXP, SEXP image_pathSEXP) {


### PR DESCRIPTION
Hi @Non-Contradiction 

Thank you for all your work on this very useful package. I was using the following code in a code chunk in a R Markdown file 

```R
JuliaCall::julia_command("VERSION") 
```

and got the following warning 

```R
## Warning: The internal function knitr:::wrap() has been deprecated. Please use
## the exported function knitr::sew() instead.

## Warning: The internal function knitr:::wrap() has been deprecated. Please use
## the exported function knitr::sew() instead.
``` 


I've updated the corresponding code with `sew()` that has been introduced in `knitr` 1.33 (https://github.com/yihui/knitr/blob/master/NEWS.md) and will replace `wrap()`, plus it is exported. All good locally and as expected, no more warning in my example.