### PR TITLE
Update install_julia to use official releases rather than Julia_jll

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,8 @@ BugReports: https://github.com/Non-Contradiction/JuliaCall/issues
 Encoding: UTF-8
 Imports: utils,
     Rcpp (>= 0.12.7),
-    knitr (>= 1.28)
+    knitr (>= 1.28),
+    rjson
 RoxygenNote: 7.1.2
 LinkingTo: Rcpp
 NeedsCompilation: yes

--- a/man/install_julia.Rd
+++ b/man/install_julia.Rd
@@ -4,9 +4,13 @@
 \alias{install_julia}
 \title{Install Julia.}
 \usage{
-install_julia(prefix = julia_default_install_dir())
+install_julia(version = "latest", prefix = julia_default_install_dir())
 }
 \arguments{
+\item{version}{The version of Julia to install (e.g. \code{"1.6.3"}).
+Defaults to \code{"latest"}, which will install the most
+recent stable release.}
+
 \item{prefix}{the directory where Julia will be installed.
 If not set, a default location will be determined by \code{rappdirs}
 if it is installed, otherwise an error will be raised.}


### PR DESCRIPTION
## Description

Changes `install_julia` to use official releases rather than Julia_jll, since the latter is defunct and no longer updated. It is possible to install a specific version, and by default https://julialang-s3.julialang.org/bin/versions.json is queried to pull the latest stable release.

The installation code is slightly more complicated because the releases are no longer tgz on all platforms, on Windows it is a zip and on Mac it is a DMG that has to be mounted and then the .app file copied across. A byproduct of this is that an automatic installation is now indistinguishable from a normal installation.

## Related Issue

Fixes #183
