### PR TITLE
Fix for Suppressor 0.2.3

### DIFF
--- a/inst/julia/JuliaObject.jl
+++ b/inst/julia/JuliaObject.jl
@@ -74,14 +74,14 @@ end
 ## we should use JuliaObject for general AbstractArray
 @static if julia07
     @suppress_err begin
-        JuliaCall.sexpclass(x :: AbstractArray{T}) where {T} = RClass{:JuliaObject}
+        @eval JuliaCall.sexpclass(x :: AbstractArray{T}) where {T} = RClass{:JuliaObject}
     end
 
     ## AbstractArray{Any} should be converted to R List
     sexpclass(x :: AbstractArray{Any}) = RClass{:list}
 else
     @suppress_err begin
-        JuliaCall.sexp(x :: AbstractArray{T}) where {T} = sexp(JuliaObject(x))
+        @eval JuliaCall.sexp(x :: AbstractArray{T}) where {T} = sexp(JuliaObject(x))
     end
 
     ## AbstractArray{Any} should be converted to R List


### PR DESCRIPTION
Suppressor 0.2.3 includes [a change](https://github.com/JuliaIO/Suppressor.jl/pull/53) that alters the `@suppress_err` macro to no longer be at the top-level, resulting in the following error when loading the code:

```
syntax: Global method definition around JuliaCall/julia/JuliaObject.jl:77 needs to be placed at the top level, or use "eval".
```

Seems like the easiest fix is simply by adding `@eval` to these commands