### PR TITLE
update ubuntu runners to latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,13 +15,12 @@ jobs:
         config:
           - {os: windows-latest, r: 'release'}
           - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-latest, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-latest, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-latest, r: 'release'}
+          - {os: ubuntu-latest, r: 'devel'}
 
     env:
       AUTO_JULIA_INSTALL: true
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
 
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +38,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the GitHub Actions CI workflow to use ubuntu-latest instead of ubuntu-20.04, which was retired on 2025-04-15.

A few other suggested updates to the workflow configuration:

- Adds use Julia installation from  [julia-actions/setup-julia](https://github.com/julia-actions/setup-julia)@v2
- Adds Julia package caching with [julia-actions/cache](https://github.com/julia-actions/cache)@v2
- Pre-installs Suppressor and RCall Julia packages before running R CMD check, as these are required dependencies for JuliaCall
- Switches to `use-public-rspm: true` in setup-r action, which should be a more robust to configure package repositories
- Removes the old RSPM configuration from the matrix and environment variables

The Julia setup and dependency pre-installation steps ensure that required Julia packages are available before JuliaCall tries to use them during the R package check, preventing installation issues during the check process.

This has all been tested at https://github.com/sbfnk/JuliaCall/actions/runs/18752353042 (together with #265).

## Related Issue
Addresses ubuntu-20.04 runner retirement: https://github.com/actions/runner-images/issues/11101