### PR TITLE
Only show 'Julia exit.' message in interactive sessions

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -170,7 +170,7 @@ julia_setup <- function(JULIA_HOME = NULL, verbose = TRUE,
 
     reg.finalizer(.julia,
                   function(e){
-                      message("Julia exit.");
+                      if (interactive()) message("Julia exit.");
                       juliacall_atexit_hook(0);
                       },
                   onexit = TRUE)


### PR DESCRIPTION
## Description
Removes the "Julia exit." message from non-interactive sessions. Removing the finalizer altogether would also solve this (and potentially other problems, as mentioned in the Issue) but might need more discussion to avoid unintended consequences.

## Related Issue
Fixes #274 
