### PR TITLE
Apply libunwind preload to child Julia processes

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -91,7 +91,28 @@ julia_locate <- function(JULIA_HOME = NULL){
 ## It is currently used in julia_setup in zzz.R and julia_library in package.R
 julia_line <- function(command, ...){
     command <- c("--startup-file=no", command)
-    system2(file.path(.julia$bin_dir, "julia"), shQuote(command), ...)
+
+    # Workaround for Ubuntu libunwind issue (see JuliaInterop/JuliaCall#238).
+    # julia_setup in zzz.R preloads Julia's bundled libunwind in the parent R
+    # process via dyn.load, but child Julia processes spawned here inherit R's
+    # LD_LIBRARY_PATH (set by the R startup wrapper to /usr/lib/x86_64-linux-gnu)
+    # and otherwise load the buggy system libunwind 1.6.2, which segfaults
+    # during e.g. Pkg.add in install_dependency.jl.
+    extra_env <- character(0)
+    if (identical(get_os(), "linux") && !is.null(.julia$bin_dir)) {
+        libunwind_paths <- Sys.glob(file.path(.julia$bin_dir, "..", "lib",
+                                              "julia", "libunwind.so*"))
+        if (length(libunwind_paths) > 0) {
+            existing <- Sys.getenv("LD_PRELOAD")
+            extra_env <- paste0("LD_PRELOAD=",
+                                paste(c(libunwind_paths[1],
+                                        if (nzchar(existing)) existing),
+                                      collapse = " "))
+        }
+    }
+
+    system2(file.path(.julia$bin_dir, "julia"), shQuote(command),
+            env = extra_env, ...)
     # r[length(r)]
 }
 


### PR DESCRIPTION
> Note: please ignore until reviewed by @ChrisRackauckas.

## Summary

Follow-up to #265 / commit 933a238. That fix preloads Julia's bundled libunwind in the parent R process via `dyn.load`, which works for the in-process embedded Julia path (`.julia$cmd` / `setup.jl`). It does **not** propagate to child Julia processes spawned by `julia_line` (in `R/aaa.R`) via `system2`. That covers:

- `install_dependency()` → `install_dependency.jl`
- `rebuild()` → `rebuildRCall.jl`
- the version / `libjulia` probes early in `julia_setup` (`zzz.R:85`, `zzz.R:99`, `zzz.R:115`)

On Ubuntu 24+ (and any system where the R startup wrapper prepends `/usr/lib/x86_64-linux-gnu` to `LD_LIBRARY_PATH`), the child Julia inherits that path, loads system libunwind 1.6.2 (libunwind/libunwind#637), and **segfaults** during `Pkg.add` in `install_dependency.jl`. The user then sees a confusing `LoadError(... ArgumentError("Package Suppressor not found in current path"))` from `setup.jl`, because the subprocess that was supposed to install Suppressor crashed.

This is exactly the failure mode reported in SciML/diffeqr#49 (comment 4550171762):

```
Julia version 1.12.6 at location ... will be used.
Loading Julia libunwind from: .../lib/julia/libunwind.so
Loading setup script for JuliaCall...
LoadError(".../JuliaCall/julia/setup.jl", 16, ArgumentError("Package Suppressor not found in current path. ..."))
Error in .julia$cmd(...) :
  Error happens when you try to execute command ENV["R_HOME"] = "/opt/R/4.6.0/lib/R"; ...
Warning message:
In system2(file.path(.julia$bin_dir, "julia"), shQuote(command),  :
  running command '.../julia ... install_dependency.jl /opt/R/4.6.0/lib/R 2>&1' had status 139
```

The status-139 warning is the child segfault; the `Suppressor not found` error is the visible downstream symptom.

## Fix

Inject `LD_PRELOAD=<julia_libdir>/libunwind.so.8` into the env of `system2` inside `julia_line`, mirroring what the parent does via `dyn.load`. Linux-only, gated on `.julia$bin_dir` being known and a bundled libunwind being present, and respects any existing `LD_PRELOAD`.

## Test plan

- [ ] CI on Ubuntu / Mac / Windows runners
- [ ] Manual: on Ubuntu 24.04 with apt-installed R + Julia 1.12.x via juliaup, `library(JuliaCall); julia_setup(installJulia = TRUE)` should complete without status-139 and without the "Suppressor not found" follow-on
- [ ] Manual: on Ubuntu 22 / Fedora / Mac / Windows, regression-check `julia_setup` still works

I was not able to run R locally on this box (no `sudo` for r-base, and the buggy libunwind 1.6.2 isn't here either — Jammy has 1.3.2, which doesn't reproduce the segfault). The diagnosis is from reading the failure traceback in SciML/diffeqr#49 plus the libunwind bisect in #238 by @topolarity and @mlechu. Verification on a real Ubuntu 24 + R 4.6 box would be appreciated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)